### PR TITLE
Add NID Resolver and Function Signature Recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Features:
 - Disassembly and decompilation of VFPU instructions (see limitations below).
 - Scripts for importing and exporting PPSSPP `.sym` files (function labels).
 - Support for exporting kernel modules as object files.
+- **Automated Signature Recovery:**
+  - Support for recovering ELF section names and resolving PSP NIDs.
+  - Automatic application of function parameters and return types (based on original Python logic by **Ethanol**).
+  - Note: This feature requires the `baseImage` to be set to `08804000` to function correctly.
 
 ## Installation
 

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexPspAnalyzer.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexPspAnalyzer.java
@@ -1,0 +1,68 @@
+package ghidra.app.plugin.core.analysis;
+
+import  ghidra.app.util.ModuleType;
+
+import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalyzerType;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.listing.Program;
+import ghidra.util.task.TaskMonitor;
+import ghidra.program.model.lang.Processor;
+import ghidra.program.model.lang.Register;
+//import ghidra.app.services.AnalyzerOptions;
+import ghidra.framework.options.Options;
+import ghidra.util.exception.CancelledException;
+import ghidra.program.model.symbol.FlowType;
+import allegrex.analysis.RecoverSections;
+
+@SuppressWarnings("unused")
+public class AllegrexPspAnalyzer extends AbstractAnalyzer {
+	private boolean doSectionRecovery = false;
+  private boolean pspResolveNIDs = false;
+	
+	private static final String NAME = "PSP Analyzer (Allegrex)";
+	private static final String DESCRIPTION = "Analyze PSP";
+  private static final String OPTION_RECOVER = "Recover Sections (Exports, Imports, lib stub, rodata sceModuleInfo, etc)";
+  private static final String OPTION_NIDS = "Resolver NIDs";
+
+  public AllegrexPspAnalyzer () {
+    super(NAME, DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
+  }
+  
+  @Override
+  public void registerOptions(Options options, Program program){
+	      super.registerOptions(options, program);
+        options.registerOption(OPTION_RECOVER, doSectionRecovery, null, "Recover PSP sections");
+        options.registerOption(OPTION_NIDS, doSectionRecovery, null, "Resolver PSP NIDs");
+  }
+  
+  @Override
+  public void optionsChanged(Options options, Program program){
+	      super.optionsChanged(options, program);
+        doSectionRecovery = options.getBoolean(OPTION_RECOVER, doSectionRecovery);
+        pspResolveNIDs = options.getBoolean(OPTION_NIDS, pspResolveNIDs);
+  }
+  
+  @Override
+  public boolean canAnalyze(Program program){
+    return program.getLanguage().getProcessor().equals(Processor.findOrPossiblyCreateProcessor("Allegrex"));
+  }
+  
+    @Override
+  public boolean added (Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
+    throws CancelledException {
+
+      if (doSectionRecovery == true) {
+        try {
+            RecoverSections.RecoverSections(program, pspResolveNIDs);
+        } catch (Exception e) {
+            //log.appendMsg("Erro na recuperação de seções: " + e.getMessage());
+            log.appendException(e);
+            return false; 
+        }
+    }
+
+		return true;
+	}
+}

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
@@ -1,0 +1,219 @@
+package allegrex.analysis;
+// Ghidra Util Static
+
+import static ghidra.app.util.Utils.*;
+
+// Ghidra depedenced
+import ghidra.program.model.listing.*;
+import ghidra.program.model.data.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.address.*;
+import ghidra.program.model.mem.*;
+import ghidra.program.model.scalar.Scalar;
+import ghidra.program.model.listing.Listing;
+
+// Java depedence
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class AllegrexResolveExports {
+
+    private Program program;
+    private Memory memory;
+    private SymbolTable symbolTable;
+    private ExternalManager extMan;
+    private FunctionManager functionManager;
+
+    public AllegrexResolveExports(Program program) {
+        this.program = program;
+        this.memory = program.getMemory();
+        this.symbolTable = program.getSymbolTable();
+        this.extMan = program.getExternalManager();
+        this.functionManager = program.getFunctionManager();
+    }
+
+    public void Resolve(Address exportsAddr, Address exportsEnd, String moduleName, SectionTracker tracker, Boolean resolveNid) throws Exception {
+
+        int[] pivotTableSizes = {
+            0x0,
+            0x4,
+            0x10,
+            0x20,
+            0x40,
+            0x80,
+            0x100,
+            0x200};
+
+        Structure[] exportDts = createModuleExportStructs(program);
+
+        Structure exportDt1 = exportDts[0];
+        Structure exportDt2 = exportDts[1];
+        int exportDtLen = exportDt1.getLength();
+
+        long size = exportsEnd.getOffset() - exportsAddr.getOffset();
+        if (size < exportDtLen) {
+            return;
+        }
+        program.getListing().clearCodeUnits(exportsAddr, exportsEnd, false);
+
+        Address addr = exportsAddr;
+        List<Data> modules = new ArrayList<>();
+        List<Long> sceResGuesses = new ArrayList<>();
+
+        while (addr.add(exportDtLen).compareTo(exportsEnd) <= 0) {
+
+            byte entryLen = memory.getByte(addr.add(8));
+
+            if (entryLen == 4) {
+                placeDataType(program, addr, exportDt1);
+            } else if (entryLen == 5) {
+                placeDataType(program, addr, exportDt2);
+            } else {
+                throw new RuntimeException("Unknown export entry size: " + entryLen);
+            }
+
+            Data module = program.getListing().getDataAt(addr);
+            modules.add(module);
+
+            addr = addr.add(4L * entryLen);
+        }
+
+        int module_index = 0;
+        for (Data module : modules) {
+
+            Address module_name_addr = (Address) module.getComponent(0).getValue();
+            String module_name;
+
+            if (module_name_addr.getOffset() != 0) {
+                module_name = getCString(program, module_name_addr);
+                program.getListing().createData(module_name_addr, new TerminatedStringDataType(), module_name.length() + 1);
+                sceResGuesses.add(module_name_addr.getOffset());
+                tracker.sceResidentSize += ((module_name.length() + 1) + 3) & ~3;
+            }
+            if (module_index == 0) {
+                module_name = moduleName;
+            } else {
+                module_name = "unknown";
+            }
+            module_index += 1;
+            int version = module.getComponent(1).getUnsignedShort(0);
+
+            if (module_name_addr.getOffset() != 0) {
+                addLabel(program, module_name_addr, String.format("_%s_ent_str", module_name), false, true);
+
+            }
+            addLabel(program, module.getAddress(), String.format("_%s_%04X_ent_head", module_name, version), false, true);
+
+            int numVars = module.getComponent(4).getUnsignedByte(0);
+            int numFuncs = module.getComponent(5).getUnsignedShort(0);
+            Address nids_base = (Address) module.getComponent(6).getValue();
+            Data num_vars_2 = module.getComponent(7);
+            Data func_pivot = module.getComponent(8);
+            Data var_pivot = module.getComponent(9);
+            Data num_alias = module.getComponent(10);
+            sceResGuesses.add(nids_base.getOffset());
+
+            if (num_vars_2 != null) {
+                int tmp = num_vars_2.getUnsignedShort(0);
+                if (tmp > numVars) {
+                    numVars = tmp;
+                }
+            }
+
+            int total_nids = numVars + numFuncs;
+            tracker.sceResidentSize += total_nids * 8;
+
+            Address stubBase = nids_base.add(total_nids * 4);
+            int num_func_pivots = 0;
+
+            if (func_pivot != null) {
+                int p = (int) ((Scalar) func_pivot.getValue()).getUnsignedValue();
+                if (p != 0) {
+                    num_func_pivots = pivotTableSizes[p];
+                }
+            }
+            int varPivotCount = 0;
+            if (var_pivot != null) {
+                int p = (int) ((Scalar) var_pivot.getValue()).getUnsignedValue();
+                if (p < pivotTableSizes.length) {
+                    varPivotCount = pivotTableSizes[p];
+                }
+            }
+
+            int total_pivots = num_func_pivots + varPivotCount;
+            tracker.sceResidentSize += total_pivots * 2;
+
+            int aliasCount = 0;
+            if (num_alias != null && num_alias.getValue() instanceof Scalar) {
+                aliasCount = (int) ((Scalar) num_alias.getValue()).getUnsignedValue();
+            }
+
+            tracker.sceResidentSize += aliasCount * (total_nids * 4 + total_pivots * 2);
+
+            for (int i = 0; i < total_nids; i++) {
+                stubBase.add(i * 4);
+                placeDataType(program, stubBase, PointerDataType.dataType);
+            }
+
+            if (numFuncs > 0) {
+                addLabel(program, nids_base, module_name + "_func_nids", true, false);
+                placeDataType(program, nids_base, new ArrayDataType(UnsignedIntegerDataType.dataType, numFuncs, 4));
+                addLabel(program, stubBase, module_name + "_funcs", true, false);
+            }
+
+            if (numVars > 0) {
+                addLabel(program, nids_base.add(numFuncs * 4), module_name + "_var_nids", true, false);
+                placeDataType(program, nids_base.add(numFuncs * 4), new ArrayDataType(UnsignedIntegerDataType.dataType, numVars, 4));
+                addLabel(program, stubBase.add(numFuncs * 4), moduleName, true, false);
+            }
+            //
+            // PIVOT TABLES
+            // ------------------------
+            tracker.sceResidentStart = tracker.sceResidentStart == null
+                    ? nids_base
+                    : (tracker.sceResidentStart.getOffset() > nids_base.getOffset()
+                    ? nids_base
+                    : tracker.sceResidentStart);
+        }
+    }
+
+    public static Structure[] createModuleExportStructs(Program program) throws Exception {
+
+        DataTypeManager dataTypeManager = program.getDataTypeManager();
+
+        EnumDataType sceLibAttr = new EnumDataType(new CategoryPath("/PSP"), "SceLibAttr", 2);
+        StructureDataType ent = new StructureDataType(new CategoryPath("/PSP"), "SceEntLibEntry", 0);
+
+        sceLibAttr.add("NO_SPECIAL_ATTR", 0x0000, "The library has no special attributes");
+        sceLibAttr.add("AUTO_EXPORT", 0x0001, "Automatically register the library to the system");
+        sceLibAttr.add("WEAK_EXPORT", 0x0002, "Indicates resident library can be overwritten");
+        sceLibAttr.add("NOLINK_EXPORT", 0x0004, "Indicates resident library is NOT being linked");
+        sceLibAttr.add("WEAK_IMPORT", 0x0008, "Load module that references this library even if this library is not registered");
+        sceLibAttr.add("SYSCALL_EXPORT", 0x4000, "Indicates the use of the SYSCALL technique for linking");
+        sceLibAttr.add("SCE_LIB_IS_SYSLIB", 0x8000, "The library is a system library");
+
+        dataTypeManager.addDataType(sceLibAttr, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        ent.add(new PointerDataType(CharDataType.dataType), "libname", null);
+        ent.add(new ArrayDataType(ByteDataType.dataType, 2, 1), "version", null);
+        ent.add(sceLibAttr, "attribute", null);
+        ent.add(ByteDataType.dataType, "size", null);
+        ent.add(ByteDataType.dataType, "num_vars", null);
+        ent.add(UnsignedShortDataType.dataType, "num_funcs", null);
+        ent.add(new PointerDataType(VoidDataType.dataType), "resident_ptr", null);
+
+        Structure dt1 = (Structure) dataTypeManager.addDataType(ent, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        ent.setName("SceEntLibEntryEx");
+        ent.setPackingEnabled(true);
+        ent.add(UnsignedShortDataType.dataType, "num_vars_2", null);
+        ent.addBitField(ByteDataType.dataType, 4, "func_pivot_size", null);
+        ent.addBitField(ByteDataType.dataType, 4, "var_pivot_size", null);
+        ent.add(ByteDataType.dataType, "alias_set_count", null);
+
+        Structure dt2 = (Structure) dataTypeManager.addDataType(ent, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        return new Structure[]{dt1, dt2};
+    }
+}

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
@@ -1,3 +1,9 @@
+// Recover some section names and apply NIDs for PSP binaries.
+// Adapted from the original Python script by Ethanol.
+// @author Ethanol (Original Script)
+// @author SHADOW (Ghidra Java Implementation)
+// @category Analysis
+
 package allegrex.analysis;
 // Ghidra Util Static
 

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveExports.java
@@ -9,7 +9,7 @@ package allegrex.analysis;
 
 import static ghidra.app.util.Utils.*;
 
-// Ghidra depedenced
+// Ghidra 
 import ghidra.program.model.listing.*;
 import ghidra.program.model.data.*;
 import ghidra.program.model.symbol.*;
@@ -18,7 +18,7 @@ import ghidra.program.model.mem.*;
 import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.listing.Listing;
 
-// Java depedence
+// Java 
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
@@ -1,0 +1,317 @@
+package allegrex.analysis;
+
+// Ghidra Util Static
+import static ghidra.app.util.Utils.*;
+
+// Ghidra depedenced
+import ghidra.program.model.listing.*;
+import ghidra.program.model.data.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.address.*;
+import ghidra.program.model.mem.*;
+import ghidra.app.util.ModuleType;
+
+// Java depedence
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class AllegrexResolveImports {
+
+    private Program program;
+    private Memory memory;
+    private SymbolTable symbolTable;
+    private ExternalManager extMan;
+    private FunctionManager functionManager;
+
+    public AllegrexResolveImports (Program program) {
+        this.program = program;
+        this.memory = program.getMemory();
+        this.symbolTable = program.getSymbolTable();
+        this.extMan = program.getExternalManager();
+        this.functionManager = program.getFunctionManager();
+    }
+    
+    public void Resolve(Address imports_addr, Address imports_end, SectionTracker tracker, Boolean resolveNid) throws Exception {
+
+        Object[] dts = createModuleImportStructs(program);
+        Structure dt1 = (Structure) dts[0];
+        Structure dt2 = (Structure) dts[1];
+        Structure dt3 = (Structure) dts[2];
+        DataType relocDt = (DataType) dts[3];
+
+        int importDtLen = dt1.getLength();
+        long entSize = imports_end.getOffset() - imports_addr.getOffset();
+
+        program.getListing().clearCodeUnits(imports_addr, imports_end, false);
+
+        int total_nids = 0;
+        List<Long> nidAddrs = new ArrayList<>();
+        List<Long> sceResGuesses = new ArrayList<>();
+
+        List<Data> modules = new ArrayList<>();
+        Address addr = imports_addr;
+
+        while (addr.add(importDtLen).compareTo(imports_end) <= 0) {
+            byte entryLen = memory.getByte(addr.add(8));
+
+            if (entryLen == 5) {
+                placeDataType(program, addr, dt1);
+            } else if (entryLen == 6) {
+                placeDataType(program, addr, dt2);
+            } else if (entryLen == 7) {
+                placeDataType(program, addr, dt3);
+            } else {
+                //throw new ExecutionControl.RunException("Unkowm Import struct Size: " + entryLen);
+            }
+            Data module = program.getListing().getDataAt(addr);
+            modules.add(module);
+            addr = addr.add(4L * entryLen);
+        }
+        tracker.sceResidentSize += modules.size() * 4;
+
+        for (Data module : modules) {
+
+            Address moduleNameAddr = (Address) module.getComponent(0).getValue();
+            String moduleName;
+
+            if (moduleNameAddr.getOffset() != 0) {
+                moduleName = getCString(program, moduleNameAddr);
+                placeDataType(program, moduleNameAddr, TerminatedStringDataType.dataType, moduleName.length() + 1);
+                tracker.sceResidentSize += ((moduleName.length() + 1) + 3) & ~3;
+            } else {
+                moduleName = "unknown";
+            }
+
+            int version = module.getComponent(1).getUnsignedShort(0);
+
+            if (moduleNameAddr.getOffset() != 0) {
+                Address versionAddr = moduleNameAddr.subtract(4);
+
+                addLabel(program, versionAddr, String.format("_sce_package_version_%s", moduleName), false, true);
+                placeDataType(program, versionAddr, UnsignedIntegerDataType.dataType);
+
+                int raw = memory.getShort(versionAddr) & 0xFFFF;
+
+                String verStr = String.format(
+                        "v%d.%d.%d.%d",
+                        raw & 0xF,
+                        (raw >> 4) & 0XF,
+                        (raw >> 8) & 0XF,
+                        (raw >> 12) & 0XF
+                );
+
+                sceResGuesses.add(moduleNameAddr.subtract(4).getOffset());
+                addLabel(program, moduleNameAddr, String.format("_%s_stub_str", moduleName), true, true);
+            }
+
+            addLabel(program, module.getAddress(), String.format("_%s_%04X_stub_head", moduleName, version), true, true);
+
+            Library lib = extMan.getExternalLibrary(moduleName);
+            if (lib == null) lib = extMan.addExternalLibraryName(moduleName, SourceType.ANALYSIS);
+
+            int numVars = module.getComponent(4).getUnsignedByte(0);
+            int numFuncs = module.getComponent(5).getUnsignedShort(0);
+            Address nidsBase = (Address) module.getComponent(6).getValue();
+            Address stubBase = (Address) module.getComponent(7).getValue();
+
+            Data varsBaseData = module.getComponent(8);
+            Data numVars2 = module.getComponent(9);
+
+            if (numVars2 != null) {
+                int v = numVars2.getUnsignedShort(0);
+                if (v > numVars) {
+                    numVars = v;
+                }
+            }
+
+            Address varsBase = null;
+
+            if (varsBaseData != null) {
+                varsBase = (Address) varsBaseData.getValue();
+            }
+
+            if (numVars != 0 && varsBase != null && varsBase.getOffset() == 0) {
+                throw new IllegalStateException(
+                        "Import Module has vars yet no variable stub offset provided"
+                );
+            }
+
+            total_nids += numFuncs;
+            
+            if(nidsBase.getOffset() != 0) {
+                nidAddrs.add(nidsBase.getOffset());
+                placeDataType(program, nidsBase, new ArrayDataType(UnsignedIntegerDataType.dataType, numFuncs, 4));
+                addLabel(program, nidsBase, moduleName + "_nids", true, false);
+            }
+            
+            // Resolver Functions
+            for (int i = 0; i < numFuncs; i++) {
+                Address nidAddr = nidsBase.add(4 * i);
+                Address stubAddr = stubBase.add(8 * i);
+
+                String nidHex = String.format("0x%08X", memory.getInt(nidAddr));
+
+                String funcName = getNameForNID(moduleName, nidHex);
+
+                Function f = functionManager.getFunctionAt(stubAddr);
+
+                if (f == null) {
+                    f = functionManager.createFunction(funcName, stubAddr, new AddressSet(stubAddr), SourceType.ANALYSIS);
+                } else if (!funcName.equals(f.getName())) {
+                    f.setName(funcName, SourceType.ANALYSIS);
+                }
+                ModuleType moduleClass = new ModuleType(program);
+                moduleClass.createModule(moduleName);
+                moduleClass.applyFunctionSignature(moduleName, nidHex, f);
+
+                ExternalLocation extLoc = extMan.addExtFunction(
+                        lib,
+                        funcName,
+                        stubAddr,
+                        SourceType.ANALYSIS
+                );
+
+                Function extFunc = extLoc.getFunction();
+
+                if (extFunc != null) {
+                    moduleClass.applyFunctionSignature(moduleName, nidHex, extFunc);
+                    f.setThunkedFunction(extFunc);
+                }
+
+                makeExternal(stubAddr, symbolTable);
+
+            }
+
+            if (numFuncs > 0) tracker.funcStubs.add(new StubInfo(moduleName, stubBase, numFuncs * 8));
+            int extra_var_bytes = 0;
+
+            for (int i = 0; i < numVars; i++) {
+                Address stubAddr = varsBase.add(8 * i);
+                Address nidAddr = varsBase.add(8 * i + 4);
+                program.getListing().clearCodeUnits(stubAddr, stubAddr.add(8 - 1), false);
+
+                placeDataType(program, stubAddr, PointerDataType.dataType);
+                placeDataType(program, nidAddr, UnsignedIntegerDataType.dataType);
+                String nidHex = String.format("0x%08X", memory.getInt(nidAddr));
+                String vName = nidHex;
+
+                long relOffset = memory.getInt(stubAddr) & 0xFFFFFFFFL;
+                Address relAddr = toAddr(program, relOffset);
+
+                int relocIndex = 0;
+
+                while (true) {
+
+                    int value = memory.getInt(
+                            relAddr.add(relocIndex * 4)
+                    );
+
+                    relocIndex++;
+
+                    if (value == 0) {
+                        break;
+                    }
+
+                    long rAddrOffset = (value & 0x03FFFFFFL) * 4;
+                    Address rAddr = toAddr(program,rAddrOffset);
+
+                    int rtype = (value >>> 26) & 0x3F;
+
+                    String msg;
+
+                    switch (rtype) {
+
+                        case 5:
+                            msg = "R_MIPS_HI16: " + vName + " from " + moduleName;
+                            break;
+
+                        case 6:
+                            msg = "R_MIPS_LO16: " + vName + " from " + moduleName;
+                            break;
+
+                        case 2:
+                            msg = "R_MIPS_32: " + vName + " from " + moduleName;
+                            break;
+
+                        default:
+                            msg = "MIPS_RELOC " + rtype + ": " + vName + " from " + moduleName;
+                            break;
+                    }
+                    
+                    //program.getListing().setComment(rAddr, CodeUnit.EOL_COMMENT, msg);
+                    extra_var_bytes += relocIndex * 4;
+                }
+                if (numVars > 0) {
+                tracker.varsStubs.add(new StubInfo(moduleName, varsBase, numVars * 8 + extra_var_bytes));
+                }
+            }
+
+            tracker.sceNidStart = toAddr(program, Collections.min(nidAddrs));
+            tracker.sceNidSize = total_nids * 4;
+
+            long guess = Collections.min(sceResGuesses);
+
+            if (tracker.sceResidentStart == null
+                    || guess < tracker.sceResidentStart.getOffset()) {
+                tracker.sceResidentStart = toAddr(program, guess);
+            }
+            
+        }
+    }
+        private static Object[] createModuleImportStructs(Program program) throws Exception {
+        DataTypeManager dataTypeManager = program.getDataTypeManager();
+
+        EnumDataType sceLibAttr = new EnumDataType(new CategoryPath("/PSP"), "SceLibAttr", 2);
+        EnumDataType varRelType = new EnumDataType(new CategoryPath("/PSP"), "VarRelocType", 4);
+        StructureDataType sceStub_dt = new StructureDataType(new CategoryPath("/PSP"), "SceStubLibEntry", 0);
+        StructureDataType reloc = new StructureDataType(new CategoryPath("/PSP"), "SceVarRelocEntry", 0);
+
+        sceLibAttr.add("NO_SPECIAL_ATTR", 0x0000, "The library has no special attributes");
+        sceLibAttr.add("AUTO_EXPORT", 0x0001, "Automatically register the library to the system");
+        sceLibAttr.add("WEAK_EXPORT", 0x0002, "Indicates resident library can be overwritten");
+        sceLibAttr.add("NOLINK_EXPORT", 0x0004, "Indicates resident library is NOT being linked");
+        sceLibAttr.add("WEAK_IMPORT", 0x0008, "Load module that references this library even if this library is not registered");
+        sceLibAttr.add("SYSCALL_EXPORT", 0x4000, "Indicates the use of the SYSCALL technique for linking");
+        sceLibAttr.add("SCE_LIB_IS_SYSLIB", 0x8000, "The library is a system library");
+
+        dataTypeManager.addDataType(sceLibAttr, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        sceStub_dt.add(new PointerDataType(CharDataType.dataType), "libname", null);
+        sceStub_dt.add(new ArrayDataType(ByteDataType.dataType, 2, 1), "version", null);
+        sceStub_dt.add(sceLibAttr, "attribute", null);
+        sceStub_dt.add(ByteDataType.dataType, "size", null);
+        sceStub_dt.add(ByteDataType.dataType, "num_vars", null);
+        sceStub_dt.add(UnsignedShortDataType.dataType, "num_funcs", null);
+        sceStub_dt.add(new PointerDataType(VoidDataType.dataType), "nids_ptr", null);
+        sceStub_dt.add(new PointerDataType(VoidDataType.dataType), "stubs_ptr", null);
+
+
+        Structure dt1 = (Structure) dataTypeManager.addDataType( sceStub_dt, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        sceStub_dt.setName("SceStubLibEntryVar");
+        sceStub_dt.add(new PointerDataType(VoidDataType.dataType), "vars_ptr", null);
+
+        Structure dt2 = (Structure) dataTypeManager.addDataType( sceStub_dt, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        sceStub_dt.setName("SceStubLibEntryVarEx");
+        sceStub_dt.add(UnsignedShortDataType.dataType, "num_vars_2", null);
+        sceStub_dt.add(UnsignedShortDataType.dataType, "padding", null);
+
+        Structure dt3 = (Structure) dataTypeManager.addDataType(sceStub_dt, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        varRelType.add("R_MIPS_NOME", 0);
+        varRelType.add("R_MIPS_32", 2);
+        varRelType.add("R_MIPS_H16", 5);
+        varRelType.add("R_MIPS_LO16", 6);
+
+        dataTypeManager.addDataType(varRelType, DataTypeConflictHandler.DEFAULT_HANDLER);
+
+        reloc.setPackingEnabled(true);
+        reloc.addBitField(UnsignedIntegerDataType.dataType, 26, "addr", null);
+        reloc.addBitField(varRelType, 6, "rel_type", null);
+
+        DataType relDt = dataTypeManager.addDataType(reloc, DataTypeConflictHandler.DEFAULT_HANDLER);
+        return new Object[]{dt1, dt2, dt3, relDt};
+    }
+}

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
@@ -8,7 +8,7 @@ package allegrex.analysis;
 // Ghidra Util Static
 import static ghidra.app.util.Utils.*;
 
-// Ghidra depedenced
+// Ghidra
 import ghidra.program.model.listing.*;
 import ghidra.program.model.data.*;
 import ghidra.program.model.symbol.*;
@@ -16,7 +16,7 @@ import ghidra.program.model.address.*;
 import ghidra.program.model.mem.*;
 import ghidra.app.util.ModuleType;
 
-// Java depedence
+// Java 
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/AllegrexResolveImports.java
@@ -1,3 +1,8 @@
+// Recover some section names and apply NIDs for PSP binaries.
+// Adapted from the original Python script by Ethanol.
+// @author Ethanol (Original Script)
+// @author SHADOW (Ghidra Java Implementation)
+// @category Analysis
 package allegrex.analysis;
 
 // Ghidra Util Static

--- a/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
@@ -1,3 +1,9 @@
+// Recover some section names and apply NIDs for PSP binaries.
+// Adapted from the original Python script by Ethanol.
+// @author Ethanol (Original Script)
+// @author SHADOW (Ghidra Java Implementation)
+// @category Analysis
+
 package allegrex.analysis;
 
 // Ghidra

--- a/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
@@ -1,0 +1,177 @@
+package allegrex.analysis;
+
+// Ghidra
+import static ghidra.app.util.Utils.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.data.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.address.*;
+import ghidra.program.model.mem.*;
+
+public class RecoverSections {
+
+    public static void RecoverSections(Program program, boolean nid) throws Exception {
+
+        Data sceModuleInfo = findAndModuleInfoStruct(program);
+        Data modNameData = sceModuleInfo.getComponent(2);
+        byte[] bytes = modNameData.getBytes();
+        String moduleName = new String(bytes).trim().replace(" ", "_");
+
+        long gp = sceModuleInfo.getComponent(4).getUnsignedInt(0);
+        if (gp != 0) addLabel(program, toAddr(program, gp), "_gp", true, true);
+        SectionTracker tracker = new SectionTracker();
+        
+        // Exports
+        Address exportsAddr = toAddr(program, sceModuleInfo.getComponent(5).getUnsignedInt(0));
+        Address exportsEnd = toAddr(program, sceModuleInfo.getComponent(6).getUnsignedInt(0));
+        Address exportsTop = exportsAddr.subtract(4);
+
+        if (exportsAddr.getOffset() > exportsEnd.getOffset()) {
+            throw new Exception("Irrelar exports data");
+        }
+        long size = exportsEnd.getOffset() - exportsAddr.getOffset();
+        createMemBlock(program, exportsTop, 4, ".lib.ent.top", true, false, false);
+
+        if (size != 0) {
+            createMemBlock(program, exportsAddr, (int) size, ".lib.ent", true, false, false);
+        }
+
+        createMemBlock(program, exportsEnd, 4, ".lib.ent.btm", true, false, false);
+
+        addLabel(program, exportsTop, "_begin_of_section_lib_ent", true, false);
+        addLabel(program, exportsEnd, "_end_of_section_lib_ent", true, false);
+
+        AllegrexResolveExports test2 = new AllegrexResolveExports(program);
+        test2.Resolve(exportsAddr, exportsEnd, moduleName, tracker, nid);
+
+        // imports
+        
+        Address importsAddr = toAddr(program, sceModuleInfo.getComponent(7).getUnsignedInt(0));
+        Address importsEnd = toAddr(program, sceModuleInfo.getComponent(8).getUnsignedInt(0));
+        Address importsTop = importsAddr.subtract(4);
+
+        if (importsAddr.getOffset() > importsEnd.getOffset()) {
+            throw new Exception("Irregular exports data");
+        }
+
+        long ImportsSize = importsEnd.getOffset() - importsAddr.getOffset();
+        createMemBlock(program, importsTop, 4, ".lib.stub.top", true, false, false);
+
+        if (ImportsSize != 0) createMemBlock(program, importsAddr, (int)ImportsSize, ".lib.stub", true, false, false);
+        createMemBlock(program, importsEnd, 4, ".lib.stub.btm", true, false, false);
+
+        addLabel(program, importsTop, "_begin_of_section_lib_stub", true, false);
+        addLabel(program, importsEnd, "_end_of_section_lib_stub", true, false);
+
+        AllegrexResolveImports test = new AllegrexResolveImports(program);
+        test.Resolve(importsAddr, importsEnd, tracker, nid);
+        
+        if (tracker.sceResidentStart != null) {
+            createMemBlock(program, tracker.sceResidentStart, tracker.sceResidentSize, ".rodata.sceResident", true, false, false);
+        }
+        if (tracker.sceNidStart != null) {
+            createMemBlock(program, tracker.sceNidStart, tracker.sceResidentSize, ".rodata.sceResident", true, false, false);
+        }
+
+    }
+    private static Data findAndModuleInfoStruct(Program program) throws Exception {
+        Structure sceModuleInfoDt = createModuleInfoStruct(program);
+        int sceModuleInfoDt_len = sceModuleInfoDt.getLength();
+
+        Memory memory = program.getMemory();
+        Listing listing = program.getListing();
+
+        // .lib.stub
+        MemoryBlock sceModuleInfo_section = program.getMemory().getBlock(".rodata.sceModuleInfo");
+        Address sceModuleInfoAddr;
+        if (sceModuleInfo_section == null) {
+            System.out.println("Could not find .rodata.sceModuleInfo section, calculating its location from elf program header");
+            sceModuleInfoAddr = getModuleInfoAddrFromLoadCommands(program);
+        } else {
+            sceModuleInfoAddr = sceModuleInfo_section.getStart();
+        }
+
+        createMemBlock(program, sceModuleInfoAddr, sceModuleInfoDt_len, ".rodata.sceModuleInfo", true, false, false);
+        placeDataType(program, sceModuleInfoAddr, sceModuleInfoDt);
+
+        return listing.getDataAt(sceModuleInfoAddr);
+    }
+
+    private static Structure createModuleInfoStruct(Program program) {
+        DataTypeManager dtm = program.getDataTypeManager();
+
+        // Enum SceModuleAttr
+        EnumDataType sceModuleAttr = new EnumDataType(new CategoryPath("/PSP"), "SceModuleAttr", 1);
+        sceModuleAttr.add("NONE", 0x00);
+        sceModuleAttr.add("CANT_STOP", 0x01, "Resident module - stays in memory");
+        sceModuleAttr.add("EXCLUSIVE_LOAD", 0x02, "Only one instance of the module can be loaded");
+        sceModuleAttr.add("EXCLUSIVE_START", 0x04, "Only one instance of the module can be started");
+
+        // Enum SceModulePriv
+        EnumDataType sceModulePriv = new EnumDataType(new CategoryPath("/PSP"), "SceModulePriv", 1);
+        sceModulePriv.add("USER", 0x00, "Lowest permission");
+        sceModulePriv.add("MS", 0x02, "POPS/Demo");
+        sceModulePriv.add("USB_WLAN", 0x04, "Module Gamesharing");
+        sceModulePriv.add("APP", 0x06, "Application module");
+        sceModulePriv.add("VSH", 0x08, "VSH module");
+        sceModulePriv.add("KERNEL", 0x10, "Highest permission");
+        sceModulePriv.add("KIRK_MEMLMD_LIB", 0x20, "Uses KIRK memlmd lib");
+        sceModulePriv.add("KIRK_SEMAPHORE_LIB", 0x40, "Uses KIRK semaphore lib");
+
+        // Struct SceModuleAttributes
+        StructureDataType sceModuleAttributes = new StructureDataType(new CategoryPath("/PSP"), "SceModuleAttributes", 0);
+        sceModuleAttributes.add(sceModuleAttr, "attribute", null);
+        sceModuleAttributes.add(sceModulePriv, "privilege", null);
+
+        // Struct SceModuleInfo
+        StructureDataType sceModuleInfo = new StructureDataType(new CategoryPath("/PSP"), "SceModuleInfo", 0);
+        sceModuleInfo.add(sceModuleAttributes, "modattribute", null);
+        sceModuleInfo.add(new ArrayDataType(ByteDataType.dataType, 2, 1), "modversion", null);
+        sceModuleInfo.add(new ArrayDataType(ByteDataType.dataType, 27, 1), "modname", null);
+        sceModuleInfo.add(ByteDataType.dataType, "terminal", null);
+        sceModuleInfo.add(new PointerDataType(VoidDataType.dataType), "gp_value", null);
+        sceModuleInfo.add(new PointerDataType(VoidDataType.dataType), "ent_top", null);
+        sceModuleInfo.add(new PointerDataType(VoidDataType.dataType), "ent_end", null);
+        sceModuleInfo.add(new PointerDataType(VoidDataType.dataType), "stub_top", null);
+        sceModuleInfo.add(new PointerDataType(VoidDataType.dataType), "stub_end", null);
+
+        // registrar no DataTypeManager
+        DataType existing = dtm.addDataType(sceModuleInfo, DataTypeConflictHandler.DEFAULT_HANDLER);
+        return (Structure) existing;
+    }
+
+    private static Address getModuleInfoAddrFromLoadCommands(Program program) throws Exception {
+        Memory memory = program.getMemory();
+        Listing listing = program.getListing();
+
+        MemoryBlock elfHeaders = memory.getBlock("_elfProgramHeaders");
+        if (elfHeaders == null) {
+            throw new Exception("_elfProgramHeaders section not found");
+        }
+
+        Data loadCmds = listing.getDataAt(elfHeaders.getStart());
+        if (loadCmds == null) {
+            throw new Exception("No data found at _elfProgramHeaders start");
+        }
+
+        // Fisrt load commnad
+        Data loadCmd = loadCmds.getComponent(0);
+        // 2nd component is p_offset
+        long loadOffset = loadCmd.getComponent(1).getLong(0);
+        // 4nd component is p_addr
+        long loadPaddr = loadCmd.getComponent(3).getLong(0);
+
+        // kernel prx (?????)
+        loadPaddr &= 0x7FFFFFFF;
+        loadPaddr = loadPaddr - loadOffset;
+
+        // Create Addres to loapaddr
+        Address sceModuleInfoAddr = program.getAddressFactory().getDefaultAddressSpace().getAddress(loadPaddr);
+
+        long imageBase = program.getImageBase().getOffset();
+        sceModuleInfoAddr = sceModuleInfoAddr.add(imageBase);
+
+        return sceModuleInfoAddr;
+    }
+
+}

--- a/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/RecoverSections.java
@@ -33,7 +33,7 @@ public class RecoverSections {
         Address exportsTop = exportsAddr.subtract(4);
 
         if (exportsAddr.getOffset() > exportsEnd.getOffset()) {
-            throw new Exception("Irrelar exports data");
+            throw new Exception("Malformed Exports data");
         }
         long size = exportsEnd.getOffset() - exportsAddr.getOffset();
         createMemBlock(program, exportsTop, 4, ".lib.ent.top", true, false, false);
@@ -57,7 +57,7 @@ public class RecoverSections {
         Address importsTop = importsAddr.subtract(4);
 
         if (importsAddr.getOffset() > importsEnd.getOffset()) {
-            throw new Exception("Irregular exports data");
+            throw new Exception("Malformed imports data");
         }
 
         long ImportsSize = importsEnd.getOffset() - importsAddr.getOffset();
@@ -87,7 +87,7 @@ public class RecoverSections {
         Memory memory = program.getMemory();
         Listing listing = program.getListing();
 
-        // .lib.stub
+        // .lib.stub isn't required in PRXes, so use .rodata.sceModuleInfo instead.
         MemoryBlock sceModuleInfo_section = program.getMemory().getBlock(".rodata.sceModuleInfo");
         Address sceModuleInfoAddr;
         if (sceModuleInfo_section == null) {

--- a/src/main/java/ghidra/app/plugin/core/analysis/SectionTracker.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/SectionTracker.java
@@ -1,3 +1,9 @@
+// Recover some section names and apply NIDs for PSP binaries.
+// Adapted from the original Python script by Ethanol.
+// @author Ethanol (Original Script)
+// @author SHADOW (Ghidra Java Implementation)
+// @category Analysis
+
 package allegrex.analysis;
 
 // java

--- a/src/main/java/ghidra/app/plugin/core/analysis/SectionTracker.java
+++ b/src/main/java/ghidra/app/plugin/core/analysis/SectionTracker.java
@@ -1,0 +1,46 @@
+package allegrex.analysis;
+
+// java
+import java.util.ArrayList;
+import java.util.List;
+
+// Ghidra
+import ghidra.program.model.listing.*;
+import ghidra.program.model.address.Address;
+
+public class SectionTracker{
+	final List<StubInfo> imports;
+	Address sceResidentStart;
+	int sceResidentSize;
+	Address sceNidStart;
+	int sceNidSize;
+	final List<StubInfo> funcStubs;
+	final List<StubInfo> varsStubs;
+	
+	public SectionTracker(){
+		this.imports = new ArrayList<>();
+		this.sceResidentStart = null;
+		this.sceResidentSize = 0;
+		this.sceNidStart = null;
+		this.sceNidSize = 0;
+		this.funcStubs = new ArrayList<>();
+		this.varsStubs = new ArrayList<>();
+	}
+	public List<StubInfo> getImports(){
+		return imports;
+	}
+	public Address getsceResidentStart(){
+		return sceResidentStart;
+	}
+}
+class StubInfo {
+	String name;
+	Address stubAddr;
+	int sectionSize;
+	
+	public StubInfo(String modName, Address stubAddr, int sectionSize){
+		this.name = modName;
+		this.stubAddr = stubAddr;
+		this.sectionSize = sectionSize;
+	}
+}

--- a/src/main/java/ghidra/app/util/ModuleType.java
+++ b/src/main/java/ghidra/app/util/ModuleType.java
@@ -1,0 +1,147 @@
+package ghidra.app.util;
+
+// Java depended
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.util.ArrayList;
+
+// Ghidra depnd
+import static ghidra.app.util.Utils.*;
+import ghidra.app.util.Utils.FieldJson;
+import ghidra.app.util.Utils.EnumJson;
+import ghidra.app.util.Utils.FunctionJson;
+import ghidra.app.util.Utils.StructJson;
+import ghidra.app.util.Utils.EnumValueJson;
+import ghidra.app.util.Utils.ModuleJson;
+import ghidra.app.util.Utils.TypedefJson;
+import ghidra.program.model.data.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.ParameterImpl;
+import ghidra.program.model.listing.Function.FunctionUpdateType;
+import ghidra.program.model.data.ParameterDefinitionImpl;
+
+
+public class ModuleType {
+
+
+    private Program program;
+    private DataTypeManager dtm;
+    private Gson gson;
+
+    public ModuleType (Program program) {
+        this.program = program;
+        this.dtm = program.getDataTypeManager();
+        this.gson = new Gson();
+    }
+
+    public void createModule(String moduleName) throws Exception {
+
+        InputStream is = getClass().getResourceAsStream(
+            "/NIDs/types/" + moduleName + ".json"
+        );
+
+        if (is == null) {
+            //throw new RuntimeException("JSON not found for module: " + moduleName);
+            return;
+        }
+
+        Reader reader = new InputStreamReader(is);
+        ModuleJson module = gson.fromJson(reader, ModuleJson.class);
+
+        createTypedefs(module);
+        createEnums(module);
+        createStructs(module);
+    }
+    private void createEnums(ModuleJson module) {
+
+    if (module.enums == null) return;
+
+    CategoryPath path = new CategoryPath(module.category);
+
+    for (EnumJson en : module.enums) {
+
+        EnumDataType enumDt = new EnumDataType(path, en.name, en.size);
+
+        for (EnumValueJson val : en.values) {
+            enumDt.add(val.name, val.value);
+        }
+
+        dtm.addDataType(enumDt, DataTypeConflictHandler.REPLACE_HANDLER);
+    }
+}
+private void createTypedefs(ModuleJson module) {
+    if (module.typedefs == null) return;
+
+    CategoryPath path = new CategoryPath(module.category);
+
+    for (TypedefJson td : module.typedefs) {
+        DataType baseType = resolveType(program, td.baseType);
+
+        if (baseType != null) {
+            TypedefDataType typedefDt = new TypedefDataType(path, td.name, baseType);
+            dtm.addDataType(typedefDt, DataTypeConflictHandler.REPLACE_HANDLER);
+        } else {
+            ghidra.util.Msg.warn(this, "Não foi possível resolver o tipo base para o typedef: " + td.name);
+        }
+    }
+}
+private void createStructs(ModuleJson module) {
+
+    if (module.structs == null) return;
+
+    CategoryPath path = new CategoryPath(module.category);
+
+    for (StructJson st : module.structs) {
+
+        StructureDataType struct = new StructureDataType(path, st.name, 0);
+
+        for (FieldJson field : st.fields) {
+
+            DataType fieldType = resolveType(program, field.type);
+
+            if (fieldType == null) continue;
+
+            struct.add(fieldType, field.name, null);
+        }
+
+        dtm.addDataType(struct, DataTypeConflictHandler.REPLACE_HANDLER);
+    }
+}
+public void applyFunctionSignature(String moduleName, String hexNID, Function f) throws Exception {
+    InputStream is = getClass().getResourceAsStream("/NIDs/types/" + moduleName + ".json");
+    if (is == null || f == null) return;
+
+    ModuleJson module = gson.fromJson(new InputStreamReader(is), ModuleJson.class);
+    if (module.functions == null) return;
+
+    for (FunctionJson fj : module.functions) {
+        if (fj.NID != null && fj.NID.equalsIgnoreCase(hexNID)) {
+            DataType returnType = resolveType(program, fj.returnType != null ? fj.returnType : "void");
+            
+            ArrayList<ParameterImpl> params = new ArrayList<>();
+            if (fj.values != null) {
+                for (FieldJson paramJson : fj.values) {
+                    DataType pType = resolveType(program, paramJson.type);
+                    if (pType == null) pType = DataType.DEFAULT; // fallback
+
+                    params.add(new ParameterImpl(paramJson.name, pType, program));
+                }
+            }
+
+            f.updateFunction(null, new ParameterImpl(null, returnType, program), params, Function.FunctionUpdateType.DYNAMIC_STORAGE_ALL_PARAMS, true, SourceType.USER_DEFINED);
+            
+            f.setName(fj.name, SourceType.USER_DEFINED);
+            break; 
+        }
+    }
+}
+
+
+}
+

--- a/src/main/java/ghidra/app/util/Utils.java
+++ b/src/main/java/ghidra/app/util/Utils.java
@@ -1,0 +1,249 @@
+package ghidra.app.util;
+
+// Ghidra depredenc
+import ghidra.program.model.listing.*;
+import ghidra.program.model.data.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.mem.*;
+import ghidra.program.model.address.*;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.exception.InvalidInputException;
+
+// Java depedenc
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.util.List;
+import java.util.ArrayList;
+
+public class Utils {
+
+    public static String getCString(Program program, Address addr) {
+        if (addr == null) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        Memory mem = program.getMemory();
+
+        try {
+            while (true) {
+                byte b = mem.getByte(addr);
+                if (b == 0) {
+                    break;
+                }
+                sb.append((char) b);
+                addr = addr.add(1);
+            }
+        } catch (Exception e) {
+            return "";
+        }
+
+        return sb.toString();
+    }
+        public static void placeDataType(Program program, Address addr, DataType dataType, int size) throws CodeUnitInsertionException, InvalidInputException {
+        Listing listing = program.getListing();
+        if (size == -1) {
+            int dtSize = dataType.getLength() - 1;
+            listing.clearCodeUnits(addr, addr.add(dtSize), false);
+        } else {
+            listing.clearCodeUnits(addr, addr.add(size - 1), false);
+        }
+        listing.createData(addr, dataType);
+    }
+        public static void createMemBlock(Program program, Address addr, int size, String name, boolean r, boolean w, boolean x) throws Exception {
+        Memory memory = program.getMemory();
+        MemoryBlock blkBefore = memory.getBlock(addr);
+        MemoryBlock blk;
+
+        if (blkBefore != null && blkBefore.getStart().equals(addr)) {
+            Address addrNext = addr.add(size);
+            MemoryBlock blkNext = memory.getBlock(addrNext);
+
+            blkBefore.setName(name);
+            if (blkNext != null && !blkNext.getStart().equals(addrNext)) {
+                memory.split(blkNext, addrNext);
+            }
+		} else if (blkBefore != null) {
+            memory.split(blkBefore, addr);
+            blk = memory.getBlock(addr);
+            if (blk != null) {
+                try {
+                    memory.split(blk, addr.add(size));
+                } catch (MemoryAccessException e) {
+                }
+                blk.setName(name);
+                blk.setRead(r);
+                blk.setWrite(w);
+                blk.setExecute(x);
+            }
+
+        }
+
+    }
+        public static String getNameForNID(String moduleName, String HexNid) {
+        Gson gson = new Gson();
+        InputStream is = Utils.class.getResourceAsStream(
+            "/NIDs/types/" + moduleName + ".json"
+        );
+
+        if (is == null) {
+            return moduleName + HexNid;
+        }
+
+        Reader reader = new InputStreamReader(is);
+        ModuleJson module = gson.fromJson(reader, ModuleJson.class);
+
+        for (FunctionJson fj : module.functions) {
+            if (fj.NID != null && fj.NID.equalsIgnoreCase(HexNid)) {
+                return fj.name;
+            }
+        }
+
+        return moduleName + HexNid;
+    }
+    public static void placeDataType(Program program, Address addr, DataType dataType) throws CodeUnitInsertionException, InvalidInputException {
+        Listing listing = program.getListing();
+        int dtSize = dataType.getLength() - 1;
+        listing.clearCodeUnits(addr, addr.add(dtSize), false);
+        listing.createData(addr, dataType);
+    }
+    public static void addLabel(Program program, Address addr, String name, boolean makePrimary, boolean makeExternal) throws Exception {
+        SymbolTable symbTbl = program.getSymbolTable();
+        symbTbl.createLabel(addr, name, SourceType.USER_DEFINED);
+        if (makeExternal) {
+            makeExternal(addr, symbTbl);
+        }
+    }
+
+    public static void makeExternal(Address addr, SymbolTable symbTbl) throws Exception {
+        symbTbl.addExternalEntryPoint(addr);
+    }
+
+    public static Address toAddr(Program program, long value) {
+        return program.getAddressFactory().getDefaultAddressSpace().getAddress(value);
+    }
+
+    public static DataType getDataTypeFromString2(Program program, String typeName) {
+
+    java.util.List<DataType> foundTypes = new java.util.ArrayList<>();
+    program.getDataTypeManager().findDataTypes(typeName, foundTypes);
+
+    if (!foundTypes.isEmpty()) return foundTypes.get(0);
+
+    DataTypeManager builtInMgr = BuiltInDataTypeManager.getDataTypeManager();
+    builtInMgr.findDataTypes(typeName, foundTypes);
+
+    if (!foundTypes.isEmpty()) return program.getDataTypeManager().resolve(foundTypes.get(0), DataTypeConflictHandler.DEFAULT_HANDLER);
+
+    return null;
+}
+public static DataType getDataTypeFromString(Program program, String typeName) {
+        DataTypeManager dtm = program.getDataTypeManager();
+        List<DataType> foundTypes = new ArrayList<>();
+        
+        dtm.findDataTypes(typeName, foundTypes);
+        if (!foundTypes.isEmpty()) return foundTypes.get(0);
+
+        DataTypeManager builtinMgr = BuiltInDataTypeManager.getDataTypeManager();
+        builtinMgr.findDataTypes(typeName, foundTypes);
+        
+        if (!foundTypes.isEmpty()) {
+            return dtm.resolve(foundTypes.get(0), DataTypeConflictHandler.DEFAULT_HANDLER);
+        }
+
+        return null;
+    }
+public static DataType resolveType(Program program, String typeStr) {
+        typeStr = typeStr.trim();
+
+        if (typeStr.endsWith("*")) {
+            String baseName = typeStr.substring(0, typeStr.length() - 1).trim();
+            DataType base = resolveType(program, baseName);
+            return (base != null) ? new PointerDataType(base) : new PointerDataType();
+        }
+
+        if (typeStr.contains("[") && typeStr.contains("]")) {
+            int start = typeStr.indexOf("[");
+            int end = typeStr.indexOf("]");
+            String baseName = typeStr.substring(0, start).trim();
+            int count = Integer.parseInt(typeStr.substring(start + 1, end));
+
+            DataType base = resolveType(program, baseName);
+            if (base == null) return null;
+            return new ArrayDataType(base, count, base.getLength());
+        }
+
+        return getDataTypeFromString(program, typeStr);
+    }
+public static DataType resolveType2(Program program, String typeStr) {
+    if (typeStr.endsWith("*")) {
+        String baseName = typeStr.replace("*", "").trim();
+        DataType base = getDataTypeFromString(program, baseName);
+        if (base == null) return null;
+        return new PointerDataType(base);
+    }
+
+    if (typeStr.contains("[")) {
+
+        String baseName = typeStr.substring(0, typeStr.indexOf("["));
+        int size = Integer.parseInt(
+            typeStr.substring(typeStr.indexOf("[") + 1, typeStr.indexOf("]"))
+        );
+
+        DataType base = getDataTypeFromString(program, baseName);
+        if (base == null) return null;
+
+        return new ArrayDataType(base, size, base.getLength());
+    }
+
+    return getDataTypeFromString(program, typeStr);
+}
+
+    class ModuleJson {
+
+        String module;
+        String category;
+        List<TypedefJson> typedefs;
+        List<EnumJson> enums;
+        List<StructJson> structs;
+        List<FunctionJson> functions;
+    }
+
+    class FunctionJson {
+    String name;
+    String NID;
+    List<FieldJson> values;
+    String returnType; 
+}
+
+    class TypedefJson {
+        String name;
+        String baseType;
+    }
+
+    class EnumJson {
+        String name;
+        int size;
+        boolean bitmask;
+        List<EnumValueJson> values;
+    }
+
+    class EnumValueJson {
+        String name;
+        long value;
+    }
+
+    class StructJson {
+        String name;
+        List<FieldJson> fields;
+    }
+
+    class FieldJson {
+        String name;
+        String type;
+    }
+}

--- a/src/main/resources/NIDs/types/IoFileMgrForUser.json
+++ b/src/main/resources/NIDs/types/IoFileMgrForUser.json
@@ -1,0 +1,218 @@
+{
+    "module": "IoFileMgrForUser",
+    "category": "/PSP/IoFileMgrForUser",
+    "typedefs": [
+        { "name": "SceMode", "baseType": "int" },
+        { "name": "SceOff", "baseType": "int" },
+        { "name": "SceUID", "baseType": "int" },
+        { "name": "SceSize", "baseType": "int" },
+        { "name": "SceUInt64", "baseType": "ulonglong" },
+        { "name": "SceInt64", "baseType": "longlong" }
+],
+    "enums": [{
+        "name": "SceCtrlPadPollMode",
+        "size": 4,
+        "values": [{
+            "name": "SCE_CTRL_POLL_INACTIVE",
+            "value": 0 },
+            {"name": "SCE_CTRL_POLL_ACTIVE",
+            "value": 1 }
+        ]
+    }],
+    "structs": [{
+        "name": "ScePspDateTime",
+        "fields": [
+        { "name": "year", "type": "ushort" },
+        { "name": "month", "type": "ushort" },
+        { "name": "day", "type": "ushort" },
+        { "name": "hour", "type": "ushort" },
+        { "name": "minute", "type": "ushort" },
+        { "name": "second", "type": "ushort" },
+        { "name": "microsecond", "type": "uint" }
+    ]
+    },{
+        "name": "SceIoStat",
+        "fields": [
+            { "name": "st_mode", "type": "SceMode" },
+            { "name": "st_attr", "type": "uint" },
+            { "name": "st_size", "type": "SceOff" },
+            { "name": "st_ctime", "type": "ScePspDateTime" },
+            { "name": "st_atime", "type": "ScePspDateTime" },
+            { "name": "st_mtime", "type": "ScePspDateTime" },
+            { "name": "st_private", "type": "uint[6]" }
+        ]
+    }],
+    "functions": [
+        {
+            "name": "sceIoMkdir",
+            "NID": "0x06A70004",
+            "values": [
+                { "name": "path", "type": "char*" },
+                { "name": "mode", "type": "SceMode" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoOpen",
+            "NID": "0x109F50BC",
+            "values": [
+                { "name": "file", "type": "char*" },
+                { "name": "flags", "type": "int" },
+                { "name": "mode", "type": "SceMode" }
+            ],
+            "returnType": "SceUID"
+        },
+        {
+            "name": "sceIoLseek",
+            "NID": "0x27EB27B8",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "offset", "type": "SceOff" },
+                { "name": "whence", "type": "int" }
+            ],
+            "returnType": "SceOff"
+        },
+        {
+            "name": "sceIoLseekAsync",
+            "NID": "0X71B19E77",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "offset", "type": "SceOff" },
+                { "name": "whence", "type": "int" }
+            ],
+            "returnType": "SceOff"
+        },
+        {
+            "name": "sceIoPollAsync",
+            "NID": "0x3251EA56",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "res", "type": "SceInt64*" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoDevctl",
+            "NID": "0x54F5FB11",
+            "values": [
+                { "name": "dev", "type": "char*" },
+                { "name": "cmd", "type": "uint" },
+                { "name": "indata", "type": "void*" },
+                { "name": "inlen", "type": "int" },
+                { "name": "outdata", "type": "void*" },
+                { "name": "outlen", "type": "int" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoRead",
+            "NID": "0x6A638D83",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "data", "type": "void*" },
+                { "name": "size", "type": "SceSize" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoReadAsync",
+            "NID": "0xA0B5A7C2",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "data", "type": "void*" },
+                { "name": "size", "type": "SceSize" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoWrite",
+            "NID": "0x42EC03AC",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "data", "type": "void*" },
+                { "name": "size", "type": "SceSize" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoWriteAsync",
+            "NID": "0x0FACAB19",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "data", "type": "void*" },
+                { "name": "size", "type": "SceSize" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoRemove",
+            "NID": "0xF27A9C51",
+            "values": [
+                { "name": "file", "type": "char*" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoRename",
+            "NID": "0x779103A0",
+            "values": [
+                { "name": "oldname", "type": "char*" },
+                { "name": "newname", "type": "char*" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoClose",
+            "NID": "0X810C4BC3",
+            "values": [
+                { "name": "fd", "type": "SceUID" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoCloseAsync",
+            "NID": "0XFF5940B6",
+            "values": [
+                { "name": "fd", "type": "SceUID" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoGetstat",
+            "NID": "0xACE946E8",
+            "values": [
+                { "name": "file", "type": "char*" },
+                { "name": "stat", "type": "SceIoStat*" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoChstat",
+            "NID": "0xB8A740F4",
+            "values": [
+                { "name": "file", "type": "char*" },
+                { "name": "stat", "type": "SceIoStat*" },
+                { "name": "bits", "type": "int" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoWaitAsync",
+            "NID": "0xE23EEC33",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "res", "type": "SceInt64*" }
+            ],
+            "returnType": "int"
+        },
+        {
+            "name": "sceIoWaitAsyncCB",
+            "NID": "0x35DBD746",
+            "values": [
+                { "name": "fd", "type": "SceUID" },
+                { "name": "res", "type": "SceInt64*" }
+            ],
+            "returnType": "int"
+        }
+    ]
+}

--- a/src/main/resources/NIDs/types/index.json
+++ b/src/main/resources/NIDs/types/index.json
@@ -1,0 +1,5 @@
+{
+    "files": [
+        "sceCtrl.json"
+    ]
+}

--- a/src/main/resources/NIDs/types/sceCtrl.json
+++ b/src/main/resources/NIDs/types/sceCtrl.json
@@ -1,0 +1,54 @@
+{
+    "module": "sceCtrl",
+    "category": "/PSP/sceCtrl",
+    "typedefs": [{
+        "name": "u32",
+        "baseType": "uint32"
+    },{
+        "name": "uint8",
+        "baseType": "uint8"
+    }
+],
+    "enums": [{
+        "name": "SceCtrlPadPollMode",
+        "size": 4,
+        "values": [{
+            "name": "SCE_CTRL_POLL_INACTIVE",
+            "value": 0 },
+            {"name": "SCE_CTRL_POLL_ACTIVE",
+            "value": 1 }
+        ]
+    }],
+    "structs": [{
+        "name": "SceCtrlData",
+        "fields": [
+        { "name": "timeStamp", "type": "uint" },
+        { "name": "buttons", "type": "uint" },
+        { "name": "aX", "type": "byte" },
+        { "name": "aY", "type": "byte" },
+        { "name": "rX", "type": "byte" },
+        { "name": "rY", "type": "byte" },
+        { "name": "rsrv", "type": "byte[4]" }
+    ]
+    }],
+    "functions": [
+        {
+            "name": "sceCtrlReadBufferPositive",
+            "NID": "0x1F803938",
+            "values": [{
+                "name": "pData",
+                "type": "SceCtrlData*" },{
+                "name": "nBufs",
+                "type": "byte" }],
+            "returnType": "uint"
+        },
+        {
+            "name": "sceCtrlSetSamplingMode",
+            "NID": "0X1F4011E6",
+            "values": [{
+                "name": "pMode",
+                "type": "byte*" }],
+            "returnType": "uint"
+        }
+    ]
+}


### PR DESCRIPTION
Hello! I've been planning this PR for a while and it's finally ready. This contribution adds a robust metadata recovery system for PSP binaries, focused on NIDs and type reconstruction.

**What’s New?**

- Section Recovery: Restores critical sections (.lib.stub, sceModuleInfo, etc.) that aid in initial analysis.
- NID Resolution: Identifies external functions through their NIDs.
- Type & Signature Recovery: Automatically reconstructs parameters, return types, `structs`, `enums`, and `typedefs` based on JSON definitions.
- Integration: Adapted from the original Python logic developed by **Ethanol**.

**How it Works**
The Analyzer now has three main options:

- Recover Sections: It identifies the sections and locates the NIDs (without immediately renaming them).
- Resolve NIDs: Enables renaming and the application of signatures (parameters/returns).
- Execution order: The script ensures that `typedefs`, `enums`, and `structs` are created before processing the functions, preventing type conflict errors.

Technical Notes & Limitations
**Requirement**: The Image Base must be set to `08804000` for the section location to work correctly.
- Database: Not all NIDs have been included yet (many are still missing!). However, the system is modular.
- Extensibility: To add new NIDs, simply create a file in `src/main/resources/NIDs/types/` following the established JSON standard.
- Pivots: They were ignored in this initial implementation, but support can be added in the future.
- 
``All of this functionality was initially created in Ghidra 11, but I recently updated to Ghidra 12.
Just to be clear, it works in both versions.``
